### PR TITLE
Add more patches for file moves in CVS.

### DIFF
--- a/fuse-emulator.lift
+++ b/fuse-emulator.lift
@@ -331,6 +331,81 @@ print * Clean cvs history: svga UI moves
 <14> add D fuse/svga.c
 <14> add D fuse/svga.h
 
+print * Clean cvs history: widget UI moves 1
+<45>..<77> expunge fuse/widget/widget.c
+<78> remove deletes
+<78> add R fuse/widget.c fuse/widget/widget.c
+
+print * Clean cvs history: widget UI moves 2
+<45>..<79> expunge fuse/widget/widget.h
+<80> remove deletes
+<80> add R fuse/widget.h fuse/widget/widget.h
+
+print * Clean cvs history: myglib moves 1
+<14>..<118> expunge fuse/myglib/myglib.c
+<14>..<118> expunge fuse/myglib/myglib.h
+<119> remove deletes
+<119> add R fuse/myglib.c fuse/myglib/myglib.c
+<119> add R fuse/myglib.h fuse/myglib/myglib.h
+
+print * Clean cvs history: GTK+ UI moves
+<6>..<225> expunge fuse/ui/gtk/gtkdisplay.c
+<6>..<226> expunge fuse/ui/gtk/gtkdisplay.h
+<6>..<225> expunge fuse/ui/gtk/gtkkeyboard.c
+<6>..<225> expunge fuse/ui/gtk/gtkkeyboard.h
+<6>..<225> expunge fuse/ui/gtk/gtkui.c
+<6>..<225> expunge fuse/ui/gtk/gtkui.h
+<226> remove fuse/gtkdisplay.c
+<226> remove fuse/gtkkeyboard.c
+<226> remove fuse/gtkkeyboard.h
+<226> remove fuse/gtkui.c
+<226> remove fuse/gtkui.h
+<226> add R fuse/gtkdisplay.c fuse/ui/gtk/gtkdisplay.c
+<226> add R fuse/gtkkeyboard.c fuse/ui/gtk/gtkkeyboard.c
+<226> add R fuse/gtkkeyboard.h fuse/ui/gtk/gtkkeyboard.h
+<226> add R fuse/gtkui.c fuse/ui/gtk/gtkui.c
+<226> add R fuse/gtkui.h fuse/ui/gtk/gtkui.h
+
+print * Clean cvs history: aalib and fb UI moves
+<50>..<228> expunge fuse/ui/aalib/aalibdisplay.c
+<50>..<228> expunge fuse/ui/aalib/aalibkeyboard.c
+<50>..<228> expunge fuse/ui/aalib/aalibkeyboard.h
+<50>..<228> expunge fuse/ui/aalib/aalibui.c
+<50>..<228> expunge fuse/ui/aalib/aalibui.h
+<229> remove fuse/aalibdisplay.c
+<229> remove fuse/aalibkeyboard.c
+<229> remove fuse/aalibkeyboard.h
+<229> remove fuse/aalibui.c
+<229> remove fuse/aalibui.h
+<229> add R fuse/aalibdisplay.c fuse/ui/aalib/aalibdisplay.c
+<229> add R fuse/aalibkeyboard.c fuse/ui/aalib/aalibkeyboard.c
+<229> add R fuse/aalibkeyboard.h fuse/ui/aalib/aalibkeyboard.h
+<229> add R fuse/aalibui.c fuse/ui/aalib/aalibui.c
+<229> add R fuse/aalibui.h fuse/ui/aalib/aalibui.h
+<14>..<228> expunge fuse/ui/fb/fbdisplay.c
+<14>..<228> expunge fuse/ui/fb/fbkeyboard.c
+<14>..<228> expunge fuse/ui/fb/fbkeyboard.h
+<14>..<228> expunge fuse/ui/fb/fbui.c
+<229> remove fuse/fbdisplay.c
+<229> remove fuse/fbkeyboard.c
+<229> remove fuse/fbkeyboard.h
+<229> remove fuse/fbui.c
+<229> add R fuse/fbdisplay.c fuse/ui/fb/fbdisplay.c
+<229> add R fuse/fbkeyboard.c fuse/ui/fb/fbkeyboard.c
+<229> add R fuse/fbkeyboard.h fuse/ui/fb/fbkeyboard.h
+<229> add R fuse/fbui.c fuse/ui/fb/fbui.c
+
+print * Clean cvs history: UI header moves
+<14>..<229> expunge fuse/ui/ui.h
+<14>..<229> expunge fuse/ui/uidisplay.h
+<230> remove deletes
+<230> add R fuse/ui.h fuse/ui/ui.h
+<230> add R fuse/uidisplay.h fuse/ui/uidisplay.h
+
+print * Clean cvs history: myglib moves 2
+<14>..<582> expunge libspectrum/myglib.c
+<583> add C fuse/myglib/myglib.c libspectrum/myglib.c
+
 print * Tag creation
 
 # Tag git conversion

--- a/fuse-emulator.lift
+++ b/fuse-emulator.lift
@@ -406,6 +406,17 @@ print * Clean cvs history: myglib moves 2
 <14>..<582> expunge libspectrum/myglib.c
 <583> add C fuse/myglib/myglib.c libspectrum/myglib.c
 
+print * Clean cvs history: sound moves
+<1753>..<2034> expunge fuse/sound/dxsound.c
+<14>..<2034> expunge fuse/sound/osssound.c
+<882>..<2034> expunge fuse/sound/sdlsound.c
+<348>..<2034> expunge fuse/sound/sunsound.c
+<2035> remove deletes
+<2035> add R fuse/dxsound.c fuse/sound/dxsound.c
+<2035> add R fuse/osssound.c fuse/sound/osssound.c
+<2035> add R fuse/sdlsound.c fuse/sound/sdlsound.c
+<2035> add R fuse/sunsound.c fuse/sound/sunsound.c
+
 print * Tag creation
 
 # Tag git conversion

--- a/fuse-emulator.lift
+++ b/fuse-emulator.lift
@@ -417,6 +417,49 @@ print * Clean cvs history: sound moves
 <2035> add R fuse/sdlsound.c fuse/sound/sdlsound.c
 <2035> add R fuse/sunsound.c fuse/sound/sunsound.c
 
+print * Clean cvs history: machines moves
+<1176>..<2078> expunge fuse/machines/pentagon.c
+<1176>..<2078> expunge fuse/machines/pentagon.h
+<2023>..<2078> expunge fuse/machines/scorpion.c
+<2023>..<2078> expunge fuse/machines/scorpion.h
+<2>..<2078> expunge fuse/machines/spec128.c
+<2>..<2078> expunge fuse/machines/spec128.h
+<1005>..<2078> expunge fuse/machines/spec16.c
+<1005>..<2078> expunge fuse/machines/spec16.h
+<2>..<2078> expunge fuse/machines/spec48.c
+<2>..<2078> expunge fuse/machines/spec48.h
+<2>..<2078> expunge fuse/machines/specplus2.c
+<2>..<2078> expunge fuse/machines/specplus2.h
+<465>..<2078> expunge fuse/machines/specplus2a.c
+<465>..<2078> expunge fuse/machines/specplus2a.h
+<2>..<2078> expunge fuse/machines/specplus3.c
+<2>..<2078> expunge fuse/machines/specplus3.h
+<443>..<2078> expunge fuse/machines/tc2048.c
+<443>..<2078> expunge fuse/machines/tc2048.h
+<1195>..<2078> expunge fuse/machines/tc2068.c
+<1195>..<2078> expunge fuse/machines/tc2068.h
+<2079> remove deletes
+<2079> add R fuse/pentagon.c fuse/machines/pentagon.c
+<2079> add R fuse/pentagon.h fuse/machines/pentagon.h
+<2079> add R fuse/scorpion.c fuse/machines/scorpion.c
+<2079> add R fuse/scorpion.h fuse/machines/scorpion.h
+<2079> add R fuse/spec128.c fuse/machines/spec128.c
+<2079> add R fuse/spec128.h fuse/machines/spec128.h
+<2079> add R fuse/spec16.c fuse/machines/spec16.c
+<2079> add R fuse/spec16.h fuse/machines/spec16.h
+<2079> add R fuse/spec48.c fuse/machines/spec48.c
+<2079> add R fuse/spec48.h fuse/machines/spec48.h
+<2079> add R fuse/specplus2.c fuse/machines/specplus2.c
+<2079> add R fuse/specplus2.h fuse/machines/specplus2.h
+<2079> add R fuse/specplus2a.c fuse/machines/specplus2a.c
+<2079> add R fuse/specplus2a.h fuse/machines/specplus2a.h
+<2079> add R fuse/specplus3.c fuse/machines/specplus3.c
+<2079> add R fuse/specplus3.h fuse/machines/specplus3.h
+<2079> add R fuse/tc2048.c fuse/machines/tc2048.c
+<2079> add R fuse/tc2048.h fuse/machines/tc2048.h
+<2079> add R fuse/tc2068.c fuse/machines/tc2068.c
+<2079> add R fuse/tc2068.h fuse/machines/tc2068.h
+
 print * Tag creation
 
 # Tag git conversion


### PR DESCRIPTION
r78 File moved into `widget' directory.
r80 Moved widget files into their own subdirectory.
r119 Move glib replacement code into its own subdirectory.
r226 Move GTK+ UI sources to their own directory.
r229 Moved aalib and framebuffer UIs into their own directories.
r230 Moved ui.h and uidisplay.h into the ui subdirectory.
